### PR TITLE
Update scripts and add bin sections in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "rm -rf ./dist && tsc",
     "test": "jest || echo \"No tests yet\" && exit 0",
-    "lint": "eslint ./src "
+    "lint": "eslint ./src --fix ",
+    "postbuild": "chmod +x dist/index.js", 
+    "global-install": "npm install -g ."
   },
   "keywords": [],
   "author": "Hamza RACHIDI & Qiuling LIN",
@@ -24,5 +26,8 @@
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.18.2"
+  },
+  "bin": {
+    "vehicle-cli": "./dist/index.js"
   }
 }


### PR DESCRIPTION
1- Add executable permission after build for dist/index.js within " the postbuild section"  
2- Added a bin section as well as a script to install our package as a global dependency, which is necessary before starting to call "vehicle-cli" directly instead of "node dist/index.js"
3 - added --fix option for lint to fix errors automatically. 