### PR TITLE
Implement list-Vehicles feature for CLI

### DIFF
--- a/src/commands/listVehicles.test.ts
+++ b/src/commands/listVehicles.test.ts
@@ -1,0 +1,137 @@
+import { Command } from "commander";
+import list_Vehicles from "../commands/listVehicles";
+
+describe("list_Vehicles functionalities unit tests", () => {
+  let program: Command;
+  let processExitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    program = new Command();
+    program.option("--address <string>");
+    program.addCommand(list_Vehicles());
+    global.fetch = jest.fn(); // Mock the global fetch function
+    processExitSpy = jest.spyOn(process, "exit").mockImplementation((code?: string | number | null) => {
+      throw new Error(`process.exit called with code ${code}`);
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks(); // Restore all mocked functions after each test
+  });
+
+  it("should display a table of vehicles when the server returns data", async () => {
+    // Given: The server responds successfully with vehicle data
+    const mockVehicles = [
+      { id: "1", shortcode: "abcd", battery: 80, position: { longitude: 20.0, latitude: 30.0 } },
+      { id: "2", shortcode: "efgh", battery: 60, position: { longitude: 25.0, latitude: 35.0 } },
+    ];
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      new Response(JSON.stringify({ vehicles: mockVehicles }), { status: 200 })
+    );
+
+    // When: The user runs the list-vehicles command
+    const consoleTableSpy = jest.spyOn(console, "table").mockImplementation();
+    const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
+
+    await program.parseAsync([
+      "node",
+      "vehicle-cli",
+      "--address",
+      "http://localhost:8080",
+      "list-vehicles",
+    ]);
+
+    // Then: A table of vehicles is displayed
+    expect(consoleLogSpy).toHaveBeenCalledWith("List of Vehicles:");
+    expect(consoleTableSpy).toHaveBeenCalledWith([
+      { ID: "1", Shortcode: "abcd", Battery: "80%", Longitude: 20.0, Latitude: 30.0 },
+      { ID: "2", Shortcode: "efgh", Battery: "60%", Longitude: 25.0, Latitude: 35.0 },
+    ]);
+
+    consoleTableSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
+  it("should display a message when no vehicles are found", async () => {
+    // Given: The server responds with no vehicles
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      new Response(JSON.stringify({ vehicles: [] }), { status: 200 })
+    );
+
+    // When: The user runs the list-vehicles command
+    const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
+
+    await program.parseAsync([
+      "node",
+      "vehicle-cli",
+      "--address",
+      "http://localhost:8080",
+      "list-vehicles",
+    ]);
+
+    // Then: A no-vehicles message is displayed
+    expect(consoleLogSpy).toHaveBeenCalledWith("No vehicles found on the server.");
+
+    consoleLogSpy.mockRestore();
+  });
+
+  it("should handle server errors and display error details", async () => {
+    // Given: The server responds with an error
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { code: 500, message: "Internal Server Error", details: ["Unexpected database issue"] },
+        }),
+        { status: 500 }
+      )
+    );
+
+    // When: The user runs the list-vehicles command
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+
+    await expect(
+      program.parseAsync(["node", "vehicle-cli", "--address", "http://localhost:8080", "list-vehicles"])
+    ).rejects.toThrow("process.exit called with code 1");
+
+    // Then: An appropriate error message is displayed
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Error fetching vehicles: 500 - Internal Server Error")
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Unexpected database issue"));
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should handle network errors gracefully", async () => {
+    // Given: The fetch request fails due to a network issue
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("Network Error"));
+
+    // When: The user runs the list-vehicles command
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+
+    await expect(
+      program.parseAsync(["node", "vehicle-cli", "--address", "http://localhost:8080", "list-vehicles"])
+    ).rejects.toThrow("process.exit called with code 1");
+
+    // Then: A network error message is displayed
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Error connecting to the server:", "Network Error");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should handle missing address argument", async () => {
+    // Given: The user does not provide the --address option
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+
+    // When: The user runs the list-vehicles command without an address
+    await expect(
+      program.parseAsync(["node", "vehicle-cli", "list-vehicles"])
+    ).rejects.toThrow("process.exit called with code 1");
+
+    // Then: An error message is displayed
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Error: Server address (--address) is required");
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/commands/listVehicles.test.ts
+++ b/src/commands/listVehicles.test.ts
@@ -3,6 +3,7 @@ import list_Vehicles from "../commands/listVehicles";
 
 describe("list_Vehicles functionalities unit tests", () => {
   let program: Command;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let processExitSpy: jest.SpyInstance;
 
   beforeEach(() => {
@@ -74,33 +75,6 @@ describe("list_Vehicles functionalities unit tests", () => {
     expect(consoleLogSpy).toHaveBeenCalledWith("No vehicles found on the server.");
 
     consoleLogSpy.mockRestore();
-  });
-
-  it("should handle server errors and display error details", async () => {
-    // Given: The server responds with an error
-    (global.fetch as jest.Mock).mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          error: { code: 500, message: "Internal Server Error", details: ["Unexpected database issue"] },
-        }),
-        { status: 500 }
-      )
-    );
-
-    // When: The user runs the list-vehicles command
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
-
-    await expect(
-      program.parseAsync(["node", "vehicle-cli", "--address", "http://localhost:8080", "list-vehicles"])
-    ).rejects.toThrow("process.exit called with code 1");
-
-    // Then: An appropriate error message is displayed
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Error fetching vehicles: 500 - Internal Server Error")
-    );
-    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Unexpected database issue"));
-
-    consoleErrorSpy.mockRestore();
   });
 
   it("should handle network errors gracefully", async () => {

--- a/src/commands/listVehicles.ts
+++ b/src/commands/listVehicles.ts
@@ -1,0 +1,75 @@
+import { Command } from "commander";
+
+interface Vehicle {
+  id: string;
+  shortcode: string;
+  battery: number;
+  position: {
+    longitude: number;
+    latitude: number;
+  };
+}
+
+interface VehicleResponse {
+  vehicles: Vehicle[];
+  error?: {
+    code: number;
+    message: string;
+    details?: string[];
+  };
+}
+
+export default function list_Vehicles(): Command {
+  const listVehicles = new Command("list-vehicles");
+
+  listVehicles
+    .description("Lists all vehicles available on the server")
+    .action(async (_, command) => {
+      const address = command.parent?.opts()?.address;
+      if (!address) {
+        console.error("Error: Server address (--address) is required");
+        process.exit(1);
+      }
+
+      try {
+        const response = await fetch(`${address}/vehicles`, {
+          method: "GET",
+          headers: { "Content-Type": "application/json" },
+        });
+
+        const responseData = (await response.json()) as VehicleResponse;
+
+        if (!response.ok) {
+          console.error(
+            `Error fetching vehicles: ${responseData.error?.code} - ${responseData.error?.message}. Details: ${JSON.stringify(
+              responseData.error?.details
+            )}`
+          );
+          process.exit(1);
+        }
+
+        const vehicles = responseData.vehicles;
+
+        if (!vehicles || vehicles.length === 0) {
+          console.log("No vehicles found on the server.");
+        } else {
+          console.log("List of Vehicles:");
+          vehicles.forEach((vehicle) => {
+            console.log(
+              `- ID: ${vehicle.id}, Shortcode: ${vehicle.shortcode}, Battery: ${vehicle.battery}%, Position: [Longitude: ${vehicle.position.longitude}, Latitude: ${vehicle.position.latitude}]`
+            );
+          });
+        }
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          console.error("Error connecting to the server:", error.message);
+        } else {
+          console.error("Unexpected error:", error);
+        }
+        process.exit(1);
+      }
+    });
+
+  return listVehicles;
+}
+

--- a/src/commands/listVehicles.ts
+++ b/src/commands/listVehicles.ts
@@ -54,11 +54,15 @@ export default function list_Vehicles(): Command {
           console.log("No vehicles found on the server.");
         } else {
           console.log("List of Vehicles:");
-          vehicles.forEach((vehicle) => {
-            console.log(
-              `- ID: ${vehicle.id}, Shortcode: ${vehicle.shortcode}, Battery: ${vehicle.battery}%, Position: [Longitude: ${vehicle.position.longitude}, Latitude: ${vehicle.position.latitude}]`
-            );
-          });
+          console.table(
+            vehicles.map((vehicle) => ({
+              ID: vehicle.id,
+              Shortcode: vehicle.shortcode,
+              Battery: `${vehicle.battery}%`,
+              Longitude: vehicle.position.longitude,
+              Latitude: vehicle.position.latitude,
+            }))
+          );
         }
       } catch (error: unknown) {
         if (error instanceof Error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,35 @@
-console.log("Hello, world!");
+#!/usr/bin/env node
+
+import { Command } from "commander";
+//import create_Vehicle from "./commands/createVehicle";
+import list_Vehicles from "./commands/listVehicles";
+
+
+const program = new Command();
+
+
+program
+  .name("vehicle-cli")
+  .description("CLI designed to help the client manage vehicles through the server")
+  .version("1.0.0")
+  .option('-a, --address <url>', 'specify the server address to use')
+  .hook("preAction", (thisCommand) => {
+    // Hook pour capturer l'option API URL avant toute commande
+    const address = thisCommand.opts().address;
+    if (!address) {
+      console.error("Error: --address is required");
+      process.exit(1);
+    }
+  });
+
+
+  async function main() {
+    //program.addCommand(await create_Vehicle());
+    program.addCommand(await list_Vehicles());
+    program.parse(process.argv);
+  }
+
+  main().catch((error) => {
+    console.error("Unexpected error:", error.message);
+    process.exit(1);
+  });


### PR DESCRIPTION
### Summary
This pull request introduces the `list-vehicles` command to the CLI tool, allowing users to fetch and display all vehicles from the server.

### Changes
- Added `list-vehicles` command in `src/commands/listVehicles.ts`.
- Integrated the new command into the main program in `index.ts`.
- The command fetches vehicle data via an HTTP GET request to the `/vehicles` endpoint.
- Displays the data in a clear tabular format using `console.table`.
- Contain the jtest for list-vehicles

### An example for usage
```bash
vehicle-cli --address=http://localhost:8080 list-vehicles