### PR TITLE
Implement delete-Vehicle feature for CLI

### DIFF
--- a/src/commands/deleteVehicle.test.ts
+++ b/src/commands/deleteVehicle.test.ts
@@ -75,7 +75,7 @@ describe("delete_Vehicle functionalities unit tests", () => {
 
   it("should handle network errors gracefully", async () => {
     // Given: The fetch request fails due to a network issue
-    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("Network Error"));
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("fetch failed"));
 
     // When: The user tries to delete a vehicle but the server is unreachable
     const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
@@ -85,7 +85,7 @@ describe("delete_Vehicle functionalities unit tests", () => {
     ).rejects.toThrow("process.exit called with code 1");
 
     // Then: A network error message is logged
-    expect(consoleErrorSpy).toHaveBeenCalledWith("Error connecting to the server:", "Network Error");
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Error connecting to the server:", "fetch failed");
 
     consoleErrorSpy.mockRestore();
   });

--- a/src/commands/deleteVehicle.test.ts
+++ b/src/commands/deleteVehicle.test.ts
@@ -3,6 +3,7 @@ import delete_Vehicle from "../commands/deleteVehicle";
 
 describe("delete_Vehicle functionalities unit tests", () => {
   let program: Command;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let processExitSpy: jest.SpyInstance;
 
   beforeEach(() => {

--- a/src/commands/deleteVehicle.test.ts
+++ b/src/commands/deleteVehicle.test.ts
@@ -1,0 +1,125 @@
+import { Command } from "commander";
+import delete_Vehicle from "../commands/deleteVehicle";
+
+describe("delete_Vehicle functionalities unit tests", () => {
+  let program: Command;
+  let processExitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    program = new Command();
+    program.option("--address <string>");
+    program.addCommand(delete_Vehicle());
+    global.fetch = jest.fn(); // Mock the global fetch function
+    processExitSpy = jest.spyOn(process, "exit").mockImplementation((code?: string | number | null) => {
+      throw new Error(`process.exit called with code ${code}`);
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks(); // Restore all mocked functions after each test
+  });
+
+  it("should successfully delete a vehicle when a valid ID is provided", async () => {
+    // Given: The server responds successfully to the DELETE request
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ success: true, message: "Vehicle deleted successfully" }),
+        { status: 200 }
+      )
+    );
+
+    // When: The user provides a valid delete-vehicle command
+    const consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
+
+    await program.parseAsync([
+      "node",
+      "vehicle-cli",
+      "--address",
+      "http://localhost:8080",
+      "delete-vehicle",
+      "--id=1",
+    ]);
+
+    // Then: A success message is logged
+    expect(consoleLogSpy).toHaveBeenCalledWith("Vehicle with ID '1' was successfully deleted.");
+
+    consoleLogSpy.mockRestore();
+  });
+
+  it("should handle a server error when deleting a vehicle", async () => {
+    // Given: The server returns an error response
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { code: 404, message: "Not Found", details: ["Vehicle ID does not exist"] },
+        }),
+        { status: 404 }
+      )
+    );
+
+    // When: The user tries to delete a vehicle that does not exist
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+
+    await expect(
+      program.parseAsync(["node", "vehicle-cli", "--address", "http://localhost:8080", "delete-vehicle", "--id=999"])
+    ).rejects.toThrow("process.exit called with code 1");
+
+    // Then: An appropriate error message is logged
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      `Could not delete the vehicle. Error: 404 - Not Found. Details: ["Vehicle ID does not exist"]`
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should handle network errors gracefully", async () => {
+    // Given: The fetch request fails due to a network issue
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("Network Error"));
+
+    // When: The user tries to delete a vehicle but the server is unreachable
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+
+    await expect(
+      program.parseAsync(["node", "vehicle-cli", "--address", "http://localhost:8080", "delete-vehicle", "--id=1"])
+    ).rejects.toThrow("process.exit called with code 1");
+
+    // Then: A network error message is logged
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Error connecting to the server:", "Network Error");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should handle missing address argument", async () => {
+    // Given: The user does not provide the --address option
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+
+    // When: The user tries to delete a vehicle without specifying the address
+    await expect(
+      program.parseAsync(["node", "vehicle-cli", "delete-vehicle", "--id=1"])
+    ).rejects.toThrow("process.exit called with code 1");
+
+    // Then: An error message is logged
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Error: Server address (--address) is required");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should handle missing ID argument", async () => {
+    // Given: The user does not provide the --id option
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    const stderrSpy = jest.spyOn(process.stderr, "write").mockImplementation();
+  
+    // When: The user tries to delete a vehicle without specifying an ID
+    await expect(
+      program.parseAsync(["node", "vehicle-cli", "--address", "http://localhost:8080", "delete-vehicle"])
+    ).rejects.toThrow("process.exit called with code 1");
+  
+    // Then: An error message is logged to stderr by commander
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("error: required option '-i, --id <string>' not specified"));
+  
+    stderrSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+
+});

--- a/src/commands/deleteVehicle.ts
+++ b/src/commands/deleteVehicle.ts
@@ -1,0 +1,57 @@
+import { Command } from "commander";
+
+interface DeleteResponse {
+  success: boolean;
+  message?: string;
+  error?: {
+    code: number;
+    message: string;
+    details?: string[];
+  };
+}
+
+export default function delete_Vehicle(): Command {
+  const deleteVehicle = new Command("delete-vehicle");
+
+  deleteVehicle
+    .description("Deletes a vehicle by its ID from the server")
+    .requiredOption("-i, --id <string>", "ID of the vehicle to delete")
+    .action(async (options, command) => {
+      const address = command.parent?.opts()?.address;
+      if (!address) {
+        console.error("Error: Server address (--address) is required");
+        process.exit(1);
+      }
+
+      const vehicleId = options.id;
+
+      try {
+        const response = await fetch(`${address}/vehicles/${vehicleId}`, {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+        });
+
+        const responseData = (await response.json()) as DeleteResponse;
+
+        if (!response.ok) {
+          console.error(
+            `Could not delete the vehicle. Error: ${responseData.error?.code} - ${responseData.error?.message}. Details: ${JSON.stringify(
+              responseData.error?.details
+            )}`
+          );
+          process.exit(1);
+        }
+
+        console.log(`Vehicle with ID '${vehicleId}' was successfully deleted.`);
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          console.error("Error connecting to the server:", error.message);
+        } else {
+          console.error("Unexpected error:", error);
+        }
+        process.exit(1);
+      }
+    });
+
+  return deleteVehicle;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,33 @@
-console.log("Hello, world!");
+#!/usr/bin/env node
+
+import { Command } from "commander";
+import delete_Vehicle from "./commands/deleteVehicle";
+
+
+const program = new Command();
+
+
+program
+  .name("vehicle-cli")
+  .description("CLI designed to help the client manage vehicles through the server")
+  .version("1.0.0")
+  .option('-a, --address <url>', 'specify the server address to use')
+  .hook("preAction", (thisCommand) => {
+    // Hook pour capturer l'option API URL avant toute commande
+    const address = thisCommand.opts().address;
+    if (!address) {
+      console.error("Error: --address is required");
+      process.exit(1);
+    }
+  });
+
+
+  async function main() {
+    program.addCommand(await delete_Vehicle());
+    program.parse(process.argv);
+  }
+
+  main().catch((error) => {
+    console.error("Unexpected error:", error.message);
+    process.exit(1);
+  });


### PR DESCRIPTION
### Summary
This pull request adds the `delete-vehicle` command to the CLI tool, enabling users to delete a vehicle from the server by providing its ID.

### Changes
- Added the `delete-vehicle` command in `src/commands/deleteVehicle.ts`.
- Integrated the new command into the CLI program.
- The command sends an HTTP DELETE request to the `/vehicles/:id` endpoint and handles:
  - Successful deletion of a vehicle.
  - Server errors (e.g., vehicle not found, validation issues).
  - Network connectivity issues.
- Contain the jest framework's tests

### An example of usage
```bash
vehicle-cli --address=http://localhost:8080 delete-vehicle --id=<vehicle_id>